### PR TITLE
fix: checking for pandas when running the tests & installing

### DIFF
--- a/pytest_constructor_override.py
+++ b/pytest_constructor_override.py
@@ -14,7 +14,7 @@ def daft_constructor(data):
     return daft.from_pydict(data)
 
 try:
-    import pandas
+    import pandas # noqa: F401
 except ImportError:
     import subprocess
     subprocess.check_call(["uv", "pip", "install", "pandas"])


### PR DESCRIPTION
If pandas isn't installed, running the tests fails. 

I'm embarrassed to say that I think you told me how to fix this @MarcoGorelli and gave me the link to the relevant code in nw (https://github.com/narwhals-dev/narwhals/blob/0989acc72c24eab3bb265b2699f4f5219f58d93e/tests/conftest.py#L90), but I couldn't remember our discussion on how to use it. 

placing it in the `pytest_constructor_override.py` script didn't fix it, so I did my own fix. If there's a better/ more elegant way using the `pandas_constructor` function, could you remind me?

For the present solution, I did some `time` checking as when you first run it & it installs pandas it seemed a bit slow:
1.45s user 0.43s system

Once pandas is installed, with the try section:
0.67s user 0.17s system 

It is a tiny bit faster if you run it without the section, assuming pandas is installed:
0.67s user 0.15s system

Let me know what you think, thanks!
